### PR TITLE
OS X Lion: Remote

### DIFF
--- a/Source/AppleRemote/AppleRemote.m
+++ b/Source/AppleRemote/AppleRemote.m
@@ -39,6 +39,8 @@ const char* AppleRemoteDeviceName = "AppleIRController";
 #ifndef NSAppKitVersionNumber10_4
 	#define NSAppKitVersionNumber10_4 824
 #endif
+//From VLC:http://www.videolan.org/developers/vlc/modules/gui/macosx/CompatibilityFixes.h
+#define OSX_LION NSAppKitVersionNumber >= 1115.2
 
 @implementation AppleRemote
 
@@ -46,7 +48,7 @@ const char* AppleRemoteDeviceName = "AppleIRController";
 	return AppleRemoteDeviceName;
 }
 
-- (void) setCookieMappingInDictionary: (NSMutableDictionary*) _cookieToButtonMapping	{	
+- (void) setCookieMappingInDictionary: (NSMutableDictionary*) _cookieToButtonMapping	{
 	if (floor(NSAppKitVersionNumber) <= NSAppKitVersionNumber10_4) {
 		// 10.4.x Tiger
 		[_cookieToButtonMapping setObject:[NSNumber numberWithInt:kRemoteButtonPlus]		forKey:@"14_12_11_6_"];
@@ -59,7 +61,21 @@ const char* AppleRemoteDeviceName = "AppleIRController";
 		[_cookieToButtonMapping setObject:[NSNumber numberWithInt:kRemoteButtonLeft_Hold]	forKey:@"14_6_3_2_"];
 		[_cookieToButtonMapping setObject:[NSNumber numberWithInt:kRemoteButtonMenu_Hold]	forKey:@"14_6_14_6_"];
 		[_cookieToButtonMapping setObject:[NSNumber numberWithInt:kRemoteButtonPlay_Hold]	forKey:@"18_14_6_18_14_6_"];
-		[_cookieToButtonMapping setObject:[NSNumber numberWithInt:kRemoteControl_Switched]	forKey:@"19_"];			
+		[_cookieToButtonMapping setObject:[NSNumber numberWithInt:kRemoteControl_Switched]	forKey:@"19_"];
+        
+    } else if( OSX_LION ) {
+        // HACK LION: copyright VideoLan Team: http://www.videolan.org/developers/vlc/modules/gui/macosx/AppleRemote.m
+        [cookieToButtonMapping setObject:[NSNumber numberWithInt:kRemoteButtonPlus]         forKey:@"33_31_30_21_20_2_"];
+        [cookieToButtonMapping setObject:[NSNumber numberWithInt:kRemoteButtonMinus]        forKey:@"33_32_30_21_20_2_"];
+        [cookieToButtonMapping setObject:[NSNumber numberWithInt:kRemoteButtonMenu]         forKey:@"33_22_21_20_2_33_22_21_20_2_"];
+        [cookieToButtonMapping setObject:[NSNumber numberWithInt:kRemoteButtonPlay]         forKey:@"33_21_20_8_2_33_21_20_8_2_"];
+        [cookieToButtonMapping setObject:[NSNumber numberWithInt:kRemoteButtonRight]        forKey:@"33_24_21_20_2_33_24_21_20_2_"];
+        [cookieToButtonMapping setObject:[NSNumber numberWithInt:kRemoteButtonLeft]         forKey:@"33_25_21_20_2_33_25_21_20_2_"];
+        [cookieToButtonMapping setObject:[NSNumber numberWithInt:kRemoteButtonRight_Hold]   forKey:@"33_21_20_14_12_2_"];
+        [cookieToButtonMapping setObject:[NSNumber numberWithInt:kRemoteButtonLeft_Hold]    forKey:@"33_21_20_13_12_2_"];
+        [cookieToButtonMapping setObject:[NSNumber numberWithInt:kRemoteButtonMenu_Hold]    forKey:@"33_21_20_2_33_21_20_2_"];
+        //[cookieToButtonMapping setObject:[NSNumber numberWithInt:kRemoteButtonPlay_Hold]    forKey:@"33_21_20_8_2_33_21_20_8_2_"];
+        [cookieToButtonMapping setObject:[NSNumber numberWithInt:kRemoteControl_Switched]   forKey:@"33_21_20_3_2_33_21_20_3_2_"];
 	} else {
 		// 10.5.x Leopard
 		[_cookieToButtonMapping setObject:[NSNumber numberWithInt:kRemoteButtonPlus]		forKey:@"31_29_28_19_18_"];
@@ -72,7 +88,9 @@ const char* AppleRemoteDeviceName = "AppleIRController";
 		[_cookieToButtonMapping setObject:[NSNumber numberWithInt:kRemoteButtonLeft_Hold]	forKey:@"31_19_18_3_2_"];
 		[_cookieToButtonMapping setObject:[NSNumber numberWithInt:kRemoteButtonMenu_Hold]	forKey:@"31_19_18_31_19_18_"];
 		[_cookieToButtonMapping setObject:[NSNumber numberWithInt:kRemoteButtonPlay_Hold]	forKey:@"35_31_19_18_35_31_19_18_"];
-		[_cookieToButtonMapping setObject:[NSNumber numberWithInt:kRemoteControl_Switched]	forKey:@"19_"];			
+		[_cookieToButtonMapping setObject:[NSNumber numberWithInt:kRemoteControl_Switched]	forKey:@"19_"];	
+		
+      
 	}
 }
 


### PR DESCRIPTION
Hi,

I tried to add support for the Remote under OS X Lion, as is done in the VLC-code.
Next, prev & play/pause do work now. Volume up and down still give errors - but that seems to be located elsewhere. As I only know php programming I found it hard to locate these errors. Maybe you have more succes.

Besides: would it be possible for you to implement the media keys on the apple keyboards (ie. using https://github.com/nevyn/SPMediaKeyTap )?

Hope it helps!

Ruben
